### PR TITLE
Add get/setListingMetadata

### DIFF
--- a/php/src/SellerLabs/Promote/Model/Deal.php
+++ b/php/src/SellerLabs/Promote/Model/Deal.php
@@ -29,6 +29,10 @@ class Deal
      */
     protected $listingUrl;
     /**
+     * @var mixed
+     */
+    protected $listingMetadata;
+    /**
      * @var string
      */
     protected $currency;
@@ -196,6 +200,23 @@ class Deal
     public function setListingUrl($listingUrl = null)
     {
         $this->listingUrl = $listingUrl;
+        return $this;
+    }
+    /**
+     * @return mixed
+     */
+    public function getListingMetadata()
+    {
+        return $this->listingMetadata;
+    }
+    /**
+     * @param mixed $listingMetadata
+     *
+     * @return self
+     */
+    public function setListingMetadata($listingMetadata = null)
+    {
+        $this->listingMetadata = $listingMetadata;
         return $this;
     }
     /**

--- a/php/src/SellerLabs/Promote/Normalizer/DealNormalizer.php
+++ b/php/src/SellerLabs/Promote/Normalizer/DealNormalizer.php
@@ -51,6 +51,9 @@ class DealNormalizer extends SerializerAwareNormalizer implements DenormalizerIn
         if (property_exists($data, 'listingUrl')) {
             $object->setListingUrl($data->{'listingUrl'});
         }
+        if (property_exists($data, 'listingMetadata')) {
+            $object->setListingMetadata($data->{'listingMetadata'});
+        }
         if (property_exists($data, 'currency')) {
             $object->setCurrency($data->{'currency'});
         }
@@ -132,6 +135,9 @@ class DealNormalizer extends SerializerAwareNormalizer implements DenormalizerIn
         }
         if (null !== $object->getListingUrl()) {
             $data->{'listingUrl'} = $object->getListingUrl();
+        }
+        if (null !== $object->getListingMetadata()) {
+            $data->{'listingMetadata'} = $object->getListingMetadata();
         }
         if (null !== $object->getCurrency()) {
             $data->{'currency'} = $object->getCurrency();


### PR DESCRIPTION
**Summary:**
Allows us to syndicate listing metadata (like asin and other marketplace specific data).

Related: 

1. https://github.com/sellerlabs/promote-api/pull/109
2. https://github.com/sellerlabs/promote-sdk/pull/3
3. https://github.com/sellerlabs/snagshout/pull/749