### PR TITLE
feature: ability to update orders email from old one to new one

### DIFF
--- a/php/src/Snagshout/Promote/Model/SyncEmailForOrders.php
+++ b/php/src/Snagshout/Promote/Model/SyncEmailForOrders.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Copyright 2016-2020, Snagshout <developers@snagshout.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This file is part of the Merchant package
+ */
+
+namespace Snagshout\Promote\Model;
+
+class SyncEmailForOrders
+{
+    /**
+     * @var string
+     */
+    protected $oldEmail;
+
+    /**
+     * @var string
+     */
+    protected $newEmail;
+
+    /**
+     * @return string
+     */
+    public function getNewEmail(): string
+    {
+        return $this->newEmail;
+    }
+
+    /**
+     * @param null $newEmail
+     * @return self
+     */
+    public function setNewEmail($newEmail): SyncEmailForOrders
+    {
+        $this->newEmail = $newEmail;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOldEmail(): string
+    {
+        return $this->oldEmail;
+    }
+
+
+    /**
+     * @param $oldEmail
+     * @return self
+     */
+    public function setOldEmail($oldEmail): SyncEmailForOrders
+    {
+        $this->oldEmail = $oldEmail;
+
+        return $this;
+    }
+}

--- a/php/src/Snagshout/Promote/Model/SyncEmailForOrders.php
+++ b/php/src/Snagshout/Promote/Model/SyncEmailForOrders.php
@@ -26,7 +26,7 @@ class SyncEmailForOrders
     /**
      * @return string
      */
-    public function getNewEmail(): string
+    public function getNewEmail()
     {
         return $this->newEmail;
     }
@@ -35,7 +35,7 @@ class SyncEmailForOrders
      * @param null $newEmail
      * @return self
      */
-    public function setNewEmail($newEmail): SyncEmailForOrders
+    public function setNewEmail($newEmail)
     {
         $this->newEmail = $newEmail;
 
@@ -45,7 +45,7 @@ class SyncEmailForOrders
     /**
      * @return string
      */
-    public function getOldEmail(): string
+    public function getOldEmail()
     {
         return $this->oldEmail;
     }
@@ -55,7 +55,7 @@ class SyncEmailForOrders
      * @param $oldEmail
      * @return self
      */
-    public function setOldEmail($oldEmail): SyncEmailForOrders
+    public function setOldEmail($oldEmail)
     {
         $this->oldEmail = $oldEmail;
 

--- a/php/src/Snagshout/Promote/Normalizer/NormalizerFactory.php
+++ b/php/src/Snagshout/Promote/Normalizer/NormalizerFactory.php
@@ -43,6 +43,7 @@ class NormalizerFactory
         $normalizers[] = new PayloadNormalizer();
         $normalizers[] = new StoreConversionIdRequestBodyNormalizer();
         $normalizers[] = new CheckEmailRequestBodyNormalizer();
+        $normalizers[] = new SyncEmailForOrdersRequestBodyNormalizer();
 
         return $normalizers;
     }

--- a/php/src/Snagshout/Promote/Normalizer/SyncEmailForOrdersRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/SyncEmailForOrdersRequestBodyNormalizer.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Copyright 2016-2020, Snagshout <developers@snagshout.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This file is part of the Merchant package
+ */
+
+namespace Snagshout\Promote\Normalizer;
+
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
+
+class SyncEmailForOrdersRequestBodyNormalizer extends SerializerAwareNormalizer implements DenormalizerInterface, NormalizerInterface
+{
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        if ($type !== 'Snagshout\\Promote\\Model\\SyncEmailForOrders') {
+            return false;
+        }
+
+        return true;
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        if ($data instanceof \Snagshout\Promote\Model\SyncEmailForOrders) {
+            return true;
+        }
+
+        return false;
+    }
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        $object = new \Snagshout\Promote\Model\SyncEmailForOrders();
+        if (property_exists($data, 'newEmail')) {
+            $object->setNewEmail($data->{'newEmail'});
+        }
+        if (property_exists($data, 'oldEmail')) {
+            $object->setOldEmail($data->{'oldEmail'});
+        }
+
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $data = new \stdClass();
+        if (null !== $object->getNewEmail()) {
+            $data->{'newEmail'} = $object->getNewEmail();
+        }
+        if (null !== $object->getOldEmail()) {
+            $data->{'oldEmail'} = $object->getOldEmail();
+        }
+
+        return $data;
+    }
+}

--- a/php/src/Snagshout/Promote/Resource/DealsResource.php
+++ b/php/src/Snagshout/Promote/Resource/DealsResource.php
@@ -384,4 +384,35 @@ class DealsResource extends Resource
 
         return $response;
     }
+
+    /**
+     *
+     *
+     * @param \Snagshout\Promote\Model\SyncEmailForOrders $body
+     * @param array  $parameters List of parameters
+     * @param string $fetch      Fetch mode (object or response)
+     *
+     * @return \Psr\Http\Message\ResponseInterface|\Snagshout\Promote\Model\Error
+     */
+    public function syncEmailForOrders(\Snagshout\Promote\Model\SyncEmailForOrders $body, $parameters = [], $fetch = self::FETCH_OBJECT)
+    {
+        $queryParam = new QueryParam();
+        $url = '/api/v1/orders/email-sync';
+        $url = $url . ('?' . $queryParam->buildQueryString($parameters));
+        $headers = array_merge(['Host' => 'localhost'], $queryParam->buildHeaders($parameters));
+        $body = $this->serializer->serialize($body, 'json');
+        $request = $this->messageFactory->createRequest('POST', $url, $headers, $body);
+        $promise = $this->httpClient->sendAsyncRequest($request);
+        if (self::FETCH_PROMISE === $fetch) {
+            return $promise;
+        }
+        $response = $promise->wait();
+        if (self::FETCH_OBJECT == $fetch) {
+            if ('422' == $response->getStatusCode()) {
+                return $this->serializer->deserialize((string) $response->getBody(), 'Snagshout\\Promote\\Model\\Error', 'json');
+            }
+        }
+
+        return $response;
+    }
 }


### PR DESCRIPTION
**Summary:**
[Need a job to fix delinquent email snagshout orders
](https://3.basecamp.com/4139135/buckets/12350077/todos/3718833341)

**Manual Test Plan:**
Change email for shopper, balances should be the same as before, after requesting payout payment should match payable balance (with commissions)


**Are There Unit Tests? / If Not Explain Why:**
no


**How Will This Modify API Responses or API Calls For the Front-End:**
will not