### PR TITLE
Support Order's completeBy

### DIFF
--- a/php/src/Snagshout/Promote/Model/CreateOrderRequestBody.php
+++ b/php/src/Snagshout/Promote/Model/CreateOrderRequestBody.php
@@ -22,6 +22,14 @@ class CreateOrderRequestBody
      */
     protected $name;
     /**
+     * @var string
+     */
+    protected $completeBy;
+    /**
+     * @var bool
+     */
+    protected $wasCompleteBySet = false;
+    /**
      * @return string
      */
     public function getEmail()
@@ -54,6 +62,32 @@ class CreateOrderRequestBody
     public function setName($name = null)
     {
         $this->name = $name;
+
+        return $this;
+    }
+    /**
+     * @return bool
+     */
+    public function wasCompleteBySet()
+    {
+        return (bool) $this->wasCompleteBySet;
+    }
+    /**
+     * @return string
+     */
+    public function getCompleteBy()
+    {
+        return $this->completeBy;
+    }
+    /**
+     * @param string $completeBy
+     *
+     * @return self
+     */
+    public function setCompleteBy($completeBy = null)
+    {
+        $this->wasCompleteBySet = true;
+        $this->completeBy = $completeBy;
 
         return $this;
     }

--- a/php/src/Snagshout/Promote/Model/Payload.php
+++ b/php/src/Snagshout/Promote/Model/Payload.php
@@ -30,6 +30,10 @@ class Payload
      */
     protected $confirmationEmail;
     /**
+     * @var string
+     */
+    protected $completeBy;
+    /**
      * @return int
      */
     public function getId()
@@ -98,6 +102,24 @@ class Payload
     public function setConfirmationEmail($confirmationEmail = null)
     {
         $this->confirmationEmail = $confirmationEmail;
+
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getCompleteBy()
+    {
+        return $this->completeBy;
+    }
+    /**
+     * @param string $completeBy
+     *
+     * @return self
+     */
+    public function setCompleteBy($completeBy = null)
+    {
+        $this->completeBy = $completeBy;
 
         return $this;
     }

--- a/php/src/Snagshout/Promote/Normalizer/CreateOrderRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/CreateOrderRequestBodyNormalizer.php
@@ -42,6 +42,9 @@ class CreateOrderRequestBodyNormalizer extends SerializerAwareNormalizer impleme
         if (property_exists($data, 'name')) {
             $object->setName($data->{'name'});
         }
+        if (property_exists($data, 'completeBy')) {
+            $object->setCompleteBy($data->{'completeBy'});
+        }
 
         return $object;
     }
@@ -53,6 +56,9 @@ class CreateOrderRequestBodyNormalizer extends SerializerAwareNormalizer impleme
         }
         if (null !== $object->getName()) {
             $data->{'name'} = $object->getName();
+        }
+        if ($object->wasCompleteBySet()) {
+            $data->{'completeBy'} = $object->getCompleteBy();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/PayloadNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/PayloadNormalizer.php
@@ -48,6 +48,9 @@ class PayloadNormalizer extends SerializerAwareNormalizer implements Denormalize
         if (property_exists($data, 'confirmationEmail')) {
             $object->setConfirmationEmail($data->{'confirmationEmail'});
         }
+        if (property_exists($data, 'completeBy')) {
+            $object->setCompleteBy($data->{'completeBy'});
+        }
 
         return $object;
     }
@@ -65,6 +68,9 @@ class PayloadNormalizer extends SerializerAwareNormalizer implements Denormalize
         }
         if (null !== $object->getConfirmationEmail()) {
             $data->{'confirmationEmail'} = $object->getConfirmationEmail();
+        }
+        if (null !== $object->getCompleteBy()) {
+            $data->{'completeBy'} = $object->getCompleteBy();
         }
 
         return $data;


### PR DESCRIPTION
**Summary:**
Added `completeBy` to `Payload` and `CreateOrderRequestBody`.

**Are There Unit Tests? / If Not Explain Why:**
No.

**How Will This Modify API Responses or API Calls For the Front-End:**
Order completion deadline datetime now can be specified via `completeBy` attribute.