### PR TITLE
Support passing Order status in ConfirmRebateRequestBody

### DIFF
--- a/php/src/Snagshout/Promote/Model/ConfirmRebateRequestBody.php
+++ b/php/src/Snagshout/Promote/Model/ConfirmRebateRequestBody.php
@@ -17,14 +17,22 @@ class ConfirmRebateRequestBody
      * @var string
      */
     protected $email;
+
     /**
      * @var string
      */
     protected $code;
+
+    /**
+     * @var string
+     */
+    protected $status;
+
     /**
      * @var int
      */
     protected $promoteOrderId;
+
     /**
      * @return string
      */
@@ -32,6 +40,7 @@ class ConfirmRebateRequestBody
     {
         return $this->email;
     }
+
     /**
      * @param string $email
      *
@@ -43,6 +52,7 @@ class ConfirmRebateRequestBody
 
         return $this;
     }
+
     /**
      * @return string
      */
@@ -50,6 +60,7 @@ class ConfirmRebateRequestBody
     {
         return $this->code;
     }
+
     /**
      * @param string $code
      *
@@ -58,6 +69,26 @@ class ConfirmRebateRequestBody
     public function setCode($code = null): ConfirmRebateRequestBody
     {
         $this->code = $code;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    /**
+     * @param string $status
+     *
+     * @return self
+     */
+    public function setStatus($status = null): ConfirmRebateRequestBody
+    {
+        $this->status = $status;
 
         return $this;
     }

--- a/php/src/Snagshout/Promote/Normalizer/ConfirmRebateRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/ConfirmRebateRequestBodyNormalizer.php
@@ -42,6 +42,9 @@ class ConfirmRebateRequestBodyNormalizer extends SerializerAwareNormalizer imple
         if (property_exists($data, 'code')) {
             $object->setCode($data->{'code'});
         }
+        if (property_exists($data, 'status')) {
+            $object->setStatus($data->{'status'});
+        }
         if (property_exists($data, 'promoteOrderId')) {
             $object->setPromoteOrderId($data->{'promoteOrderId'});
         }
@@ -56,6 +59,9 @@ class ConfirmRebateRequestBodyNormalizer extends SerializerAwareNormalizer imple
         }
         if (null !== $object->getCode()) {
             $data->{'code'} = $object->getCode();
+        }
+        if (null !== $object->getStatus()) {
+            $data->{'status'} = $object->getStatus();
         }
         if (null !== $object->getPromoteOrderId()) {
             $data->{'promoteOrderId'} = $object->getPromoteOrderId();


### PR DESCRIPTION
**Summary:**
Added `status` parameter to `ConfirmRebateReqestBody`.

**Manual Test Plan:**

**Are There Unit Tests? / If Not Explain Why:**
No.

**How Will This Modify API Responses or API Calls For the Front-End:**
New `status` parameter can be set to specific `OrderStatus` enum string value.