### PR TITLE
Support for min and max age

### DIFF
--- a/php/src/Snagshout/Promote/Model/Deal.php
+++ b/php/src/Snagshout/Promote/Model/Deal.php
@@ -197,6 +197,14 @@ class Deal
      * @var string
      */
     protected $visibility;
+    /**
+     * @var int
+     */
+    protected $minAge;
+    /**
+     * @var int
+     */
+    protected $maxAge;
 
     /**
      * @return int
@@ -1015,7 +1023,6 @@ class Deal
     {
         return $this->visibility;
     }
-
     /**
      * @param string|null $visibility
      *
@@ -1024,6 +1031,42 @@ class Deal
     public function setVisibility(string $visibility = null): Deal
     {
         $this->visibility = $visibility;
+
+        return $this;
+    }
+    /**
+     * @return int
+     */
+    public function getMinAge(): int
+    {
+        return $this->minAge;
+    }
+    /**
+     * @param int|null $minAge
+     *
+     * @return self
+     */
+    public function setMinAge(int $minAge = null): Deal
+    {
+        $this->minAge = $minAge;
+
+        return $this;
+    }
+    /**
+     * @return int
+     */
+    public function getMaxAge(): int
+    {
+        return $this->maxAge;
+    }
+    /**
+     * @param int|null $maxAge
+     *
+     * @return self
+     */
+    public function setMaxAge(int $maxAge = null): Deal
+    {
+        $this->maxAge = $maxAge;
 
         return $this;
     }

--- a/php/src/Snagshout/Promote/Normalizer/DealNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/DealNormalizer.php
@@ -194,6 +194,12 @@ class DealNormalizer extends SerializerAwareNormalizer implements DenormalizerIn
         if (property_exists($data, 'visibility')) {
             $object->setVisibility($data->{'visibility'});
         }
+        if (property_exists($data, 'minAge')) {
+            $object->setMinAge($data->{'minAge'});
+        }
+        if (property_exists($data, 'maxAge')) {
+            $object->setMaxAge($data->{'maxAge'});
+        }
 
         return $object;
     }
@@ -354,6 +360,12 @@ class DealNormalizer extends SerializerAwareNormalizer implements DenormalizerIn
         }
         if (null !== $object->getVisibility()) {
             $data->{'visibility'} = $object->getVisibility();
+        }
+        if (null !== $object->getMinAge()) {
+            $data->{'minAge'} = $object->getMinAge();
+        }
+        if (null !== $object->getMaxAge()) {
+            $data->{'maxAge'} = $object->getMaxAge();
         }
 
         return $data;


### PR DESCRIPTION
**Summary:**
Added `minAge` and `maxAge` attributes to the `Deal` for age restrictions support for campaigns.

**Manual Test Plan:**

**Are There Unit Tests? / If Not Explain Why:**
No.

**How Will This Modify API Responses or API Calls For the Front-End:**