### PR TITLE
Cast `data` to `object` in normalizers

### DIFF
--- a/php/src/Snagshout/Promote/Client.php
+++ b/php/src/Snagshout/Promote/Client.php
@@ -62,6 +62,7 @@ class Client
             new Serializer(
                 NormalizerFactory::create(),
                 [
+                    new RawEncoder(),
                     new JsonEncoder(new JsonEncode(), new JsonDecode()),
                 ]
             )

--- a/php/src/Snagshout/Promote/Encoder/RawEncoder.php
+++ b/php/src/Snagshout/Promote/Encoder/RawEncoder.php
@@ -37,7 +37,7 @@ class RawEncoder implements DecoderInterface, EncoderInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsDecoding($format)
+    public function supportsDecoding($format): bool
     {
         return self::FORMAT === $format;
     }
@@ -45,7 +45,7 @@ class RawEncoder implements DecoderInterface, EncoderInterface
     /**
      * {@inheritdoc}
      */
-    public function encode($data, $format, array $context = array())
+    public function encode($data, $format, array $context = array()): string
     {
         return $data;
     }
@@ -53,7 +53,7 @@ class RawEncoder implements DecoderInterface, EncoderInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsEncoding($format)
+    public function supportsEncoding($format): bool
     {
         return self::FORMAT === $format;
     }

--- a/php/src/Snagshout/Promote/Normalizer/CancelRebateRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/CancelRebateRequestBodyNormalizer.php
@@ -19,6 +19,8 @@ class CancelRebateRequestBodyNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new CancelRebateRequestBody();
         if (property_exists($data, 'email')) {
             $object->setEmail($data->{'email'});

--- a/php/src/Snagshout/Promote/Normalizer/CategoryNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/CategoryNormalizer.php
@@ -19,6 +19,8 @@ class CategoryNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new Category();
         if (property_exists($data, 'id')) {
             $object->setId($data->{'id'});

--- a/php/src/Snagshout/Promote/Normalizer/CheckEmailRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/CheckEmailRequestBodyNormalizer.php
@@ -19,6 +19,8 @@ class CheckEmailRequestBodyNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new CheckEmailRequestBody();
         if (property_exists($data, 'email')) {
             $object->setEmail($data->{'email'});

--- a/php/src/Snagshout/Promote/Normalizer/CompleteFacebookOrderRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/CompleteFacebookOrderRequestBodyNormalizer.php
@@ -11,6 +11,8 @@
 
 namespace Snagshout\Promote\Normalizer;
 
+use Snagshout\Promote\Model\CompleteFacebookOrderRequestBody;
+
 class CompleteFacebookOrderRequestBodyNormalizer extends AbstractNormalizer
 {
     public function supportsDenormalization($data, $type, $format = null)
@@ -24,7 +26,7 @@ class CompleteFacebookOrderRequestBodyNormalizer extends AbstractNormalizer
 
     public function supportsNormalization($data, $format = null)
     {
-        if ($data instanceof \Snagshout\Promote\Model\CompleteFacebookOrderRequestBody) {
+        if ($data instanceof CompleteFacebookOrderRequestBody) {
             return true;
         }
 
@@ -33,7 +35,9 @@ class CompleteFacebookOrderRequestBodyNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
-        $object = new \Snagshout\Promote\Model\CompleteFacebookOrderRequestBody();
+        $data = (object) $data;
+
+        $object = new CompleteFacebookOrderRequestBody();
         if (property_exists($data, 'email')) {
             $object->setEmail($data->{'email'});
         }

--- a/php/src/Snagshout/Promote/Normalizer/ConfirmRebateRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/ConfirmRebateRequestBodyNormalizer.php
@@ -19,6 +19,8 @@ class ConfirmRebateRequestBodyNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new ConfirmRebateRequestBody();
         if (property_exists($data, 'email')) {
             $object->setEmail($data->{'email'});

--- a/php/src/Snagshout/Promote/Normalizer/CreateFacebookOrderRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/CreateFacebookOrderRequestBodyNormalizer.php
@@ -19,6 +19,8 @@ class CreateFacebookOrderRequestBodyNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new CreateFacebookOrderRequestBody();
         if (property_exists($data, 'adId')) {
             $object->setAdId($data->{'adId'});

--- a/php/src/Snagshout/Promote/Normalizer/CreateOrderRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/CreateOrderRequestBodyNormalizer.php
@@ -19,6 +19,8 @@ class CreateOrderRequestBodyNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new CreateOrderRequestBody();
         if (property_exists($data, 'email')) {
             $object->setEmail($data->{'email'});

--- a/php/src/Snagshout/Promote/Normalizer/CreateSurveyReviewRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/CreateSurveyReviewRequestBodyNormalizer.php
@@ -19,6 +19,8 @@ class CreateSurveyReviewRequestBodyNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new CreateSurveyReviewRequestBody();
         if (property_exists($data, 'reviewClaimedLeft')) {
             $object->setReviewClaimedLeft($data->{'reviewClaimedLeft'});

--- a/php/src/Snagshout/Promote/Normalizer/DealImpressionsRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/DealImpressionsRequestBodyNormalizer.php
@@ -20,6 +20,8 @@ class DealImpressionsRequestBodyNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new DealImpressionsRequestBody();
         if (property_exists($data, 'impressions')) {
             $values = [];

--- a/php/src/Snagshout/Promote/Normalizer/DealImpressionsRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/DealImpressionsRequestBodyNormalizer.php
@@ -26,7 +26,7 @@ class DealImpressionsRequestBodyNormalizer extends AbstractNormalizer
         if (property_exists($data, 'impressions')) {
             $values = [];
             foreach ($data->{'impressions'} as $value) {
-                $values[] = $this->serializer->deserialize(json_encode($value), Impression::class, 'raw', $context);
+                $values[] = $this->serializer->deserialize(json_encode($value), Impression::class, 'json', $context);
             }
             $object->setImpressions($values);
         }

--- a/php/src/Snagshout/Promote/Normalizer/DealNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/DealNormalizer.php
@@ -42,14 +42,14 @@ class DealNormalizer extends AbstractNormalizer
         if (property_exists($data, 'categories')) {
             $values = [];
             foreach ($data->{'categories'} as $value) {
-                $values[] = $this->serializer->deserialize(json_encode($value), Category::class, 'raw', $context);
+                $values[] = $this->serializer->deserialize(json_encode($value), Category::class, 'json', $context);
             }
             $object->setCategories($values);
         }
         if (property_exists($data, 'media')) {
             $values_1 = [];
             foreach ($data->{'media'} as $value_1) {
-                $values_1[] = $this->serializer->deserialize(json_encode($value_1), Medium::class, 'raw', $context);
+                $values_1[] = $this->serializer->deserialize(json_encode($value_1), Medium::class, 'json', $context);
             }
             $object->setMedia($values_1);
         }

--- a/php/src/Snagshout/Promote/Normalizer/DealNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/DealNormalizer.php
@@ -21,6 +21,8 @@ class DealNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new Deal();
         if (property_exists($data, 'campaignId')) {
             $object->setCampaignId($data->{'campaignId'});

--- a/php/src/Snagshout/Promote/Normalizer/ErrorNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/ErrorNormalizer.php
@@ -19,6 +19,8 @@ class ErrorNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new Error();
         if (property_exists($data, 'message')) {
             $object->setMessage($data->{'message'});

--- a/php/src/Snagshout/Promote/Normalizer/FlagDealRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/FlagDealRequestBodyNormalizer.php
@@ -19,6 +19,8 @@ class FlagDealRequestBodyNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new FlagDealRequestBody();
         if (property_exists($data, 'type')) {
             $object->setType($data->{'type'});

--- a/php/src/Snagshout/Promote/Normalizer/FollowupNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/FollowupNormalizer.php
@@ -19,6 +19,8 @@ class FollowupNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new Followup();
         if (property_exists($data, 'days')) {
             $object->setDays($data->{'days'});

--- a/php/src/Snagshout/Promote/Normalizer/GetRebateEmailNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/GetRebateEmailNormalizer.php
@@ -19,6 +19,8 @@ class GetRebateEmailNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new GetRebateEmail();
         if (property_exists($data, 'fbUserId')) {
             $object->setFbUserId($data->{'fbUserId'});

--- a/php/src/Snagshout/Promote/Normalizer/GetRebateOrPromoNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/GetRebateOrPromoNormalizer.php
@@ -19,6 +19,8 @@ class GetRebateOrPromoNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new GetRebateOrPromo();
         if (property_exists($data, 'fbUserId')) {
             $object->setFbUserId($data->{'fbUserId'});

--- a/php/src/Snagshout/Promote/Normalizer/ImpressionNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/ImpressionNormalizer.php
@@ -19,6 +19,8 @@ class ImpressionNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new Impression();
         if (property_exists($data, 'views')) {
             $object->setViews($data->{'views'});

--- a/php/src/Snagshout/Promote/Normalizer/InitializeMigrationBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/InitializeMigrationBodyNormalizer.php
@@ -19,6 +19,8 @@ class InitializeMigrationBodyNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new InitializeMigrationBody();
         if (property_exists($data, 'userId')) {
             $object->setUserId($data->{'userId'});

--- a/php/src/Snagshout/Promote/Normalizer/MediumNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/MediumNormalizer.php
@@ -19,6 +19,8 @@ class MediumNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new Medium();
         if (property_exists($data, 'id')) {
             $object->setId($data->{'id'});

--- a/php/src/Snagshout/Promote/Normalizer/NotifyDealRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/NotifyDealRequestBodyNormalizer.php
@@ -19,6 +19,8 @@ class NotifyDealRequestBodyNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new NotifyDealRequestBody();
         if (property_exists($data, 'type')) {
             $object->setType($data->{'type'});

--- a/php/src/Snagshout/Promote/Normalizer/PayloadNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/PayloadNormalizer.php
@@ -19,6 +19,8 @@ class PayloadNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new Payload();
         if (property_exists($data, 'id')) {
             $object->setId($data->{'id'});

--- a/php/src/Snagshout/Promote/Normalizer/PayoutRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/PayoutRequestBodyNormalizer.php
@@ -19,6 +19,8 @@ class PayoutRequestBodyNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new RequestPayout();
         if (property_exists($data, 'email')) {
             $object->setEmail($data->{'email'});

--- a/php/src/Snagshout/Promote/Normalizer/RestoreRebateRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/RestoreRebateRequestBodyNormalizer.php
@@ -19,6 +19,8 @@ class RestoreRebateRequestBodyNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new RestoreRebateRequestBody();
         if (property_exists($data, 'email')) {
             $object->setEmail($data->{'email'});

--- a/php/src/Snagshout/Promote/Normalizer/ReviewFoundRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/ReviewFoundRequestBodyNormalizer.php
@@ -19,6 +19,8 @@ class ReviewFoundRequestBodyNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new ReviewFoundRequestBody();
         if (property_exists($data, 'createdAt')) {
             $object->setCreatedAt($data->{'createdAt'});

--- a/php/src/Snagshout/Promote/Normalizer/StoreConversionIdRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/StoreConversionIdRequestBodyNormalizer.php
@@ -19,6 +19,8 @@ class StoreConversionIdRequestBodyNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new StoreConversionIdRequestBody();
         if (property_exists($data, 'conversionId')) {
             $object->setConversionId($data->{'conversionId'});

--- a/php/src/Snagshout/Promote/Normalizer/StoreFBImpressionRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/StoreFBImpressionRequestBodyNormalizer.php
@@ -19,6 +19,8 @@ class StoreFBImpressionRequestBodyNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new StoreFBImpressionRequestBody();
         if (property_exists($data, 'fbAdId')) {
             $object->setFbAdId($data->{'fbAdId'});

--- a/php/src/Snagshout/Promote/Normalizer/SyncDealRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/SyncDealRequestBodyNormalizer.php
@@ -19,6 +19,8 @@ class SyncDealRequestBodyNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new SyncDealRequestBody();
         if (property_exists($data, 'url')) {
             $object->setUrl($data->{'url'});

--- a/php/src/Snagshout/Promote/Normalizer/SyncEmailForOrdersRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/SyncEmailForOrdersRequestBodyNormalizer.php
@@ -19,6 +19,8 @@ class SyncEmailForOrdersRequestBodyNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new SyncEmailForOrders();
         if (property_exists($data, 'newEmail')) {
             $object->setNewEmail($data->{'newEmail'});

--- a/php/src/Snagshout/Promote/Normalizer/UnsyncDealRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/UnsyncDealRequestBodyNormalizer.php
@@ -19,6 +19,8 @@ class UnsyncDealRequestBodyNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new UnsyncDealRequestBody();
         if (property_exists($data, 'note')) {
             $object->setNote($data->{'note'});

--- a/php/src/Snagshout/Promote/Normalizer/UpdateDeliverableRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/UpdateDeliverableRequestBodyNormalizer.php
@@ -19,6 +19,8 @@ class UpdateDeliverableRequestBodyNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new UpdateDeliverableRequestBody();
         if (property_exists($data, 'email')) {
             $object->setEmail($data->{'email'});

--- a/php/src/Snagshout/Promote/Normalizer/UpdateOrderRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/UpdateOrderRequestBodyNormalizer.php
@@ -19,6 +19,8 @@ class UpdateOrderRequestBodyNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new UpdateOrderRequestBody();
         if (property_exists($data, 'status')) {
             $object->setStatus($data->{'status'});

--- a/php/src/Snagshout/Promote/Normalizer/UpdateReviewNameBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/UpdateReviewNameBodyNormalizer.php
@@ -19,6 +19,8 @@ class UpdateReviewNameBodyNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new UpdateReviewNameRequestBody();
         if (property_exists($data, 'userEmail')) {
             $object->setUserEmail($data->{'userEmail'});

--- a/php/src/Snagshout/Promote/Normalizer/VersionNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/VersionNormalizer.php
@@ -19,6 +19,8 @@ class VersionNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        $data = (object) $data;
+
         $object = new Version();
         if (property_exists($data, 'api')) {
             $object->setApi($data->{'api'});

--- a/php/src/Snagshout/Promote/Resource/AbstractResource.php
+++ b/php/src/Snagshout/Promote/Resource/AbstractResource.php
@@ -56,6 +56,6 @@ abstract class AbstractResource
     public function as(ResponseInterface $response, string $class)
     {
         return $this->serializer
-            ->deserialize((string)$response->getBody(), $class, 'json');
+            ->deserialize($response->getBody()->getContents(), $class, 'json');
     }
 }

--- a/php/src/Snagshout/Promote/Resource/AbstractResource.php
+++ b/php/src/Snagshout/Promote/Resource/AbstractResource.php
@@ -55,7 +55,9 @@ abstract class AbstractResource
      */
     public function as(ResponseInterface $response, string $class)
     {
+        $data = $response->getBody()->getContents();
+
         return $this->serializer
-            ->deserialize($response->getBody()->getContents(), $class, 'json');
+            ->deserialize($data, $class, 'json');
     }
 }


### PR DESCRIPTION
**Summary**
Added logic for casting `data` parameter of normalizers `denormalize()` method to `object`