### PR TITLE
Return `array` instead of `stdClass` in `normalize()`

### DIFF
--- a/php/src/Snagshout/Promote/Normalizer/CancelRebateRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/CancelRebateRequestBodyNormalizer.php
@@ -34,12 +34,13 @@ class CancelRebateRequestBodyNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getEmail()) {
-            $data->{'email'} = $object->getEmail();
+            $data['email'] = $object->getEmail();
         }
         if (null !== $object->getPromoteOrderId()) {
-            $data->{'promoteOrderId'} = $object->getPromoteOrderId();
+            $data['promoteOrderId'] = $object->getPromoteOrderId();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/CategoryNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/CategoryNormalizer.php
@@ -34,12 +34,13 @@ class CategoryNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getId()) {
-            $data->{'id'} = $object->getId();
+            $data['id'] = $object->getId();
         }
         if (null !== $object->getName()) {
-            $data->{'name'} = $object->getName();
+            $data['name'] = $object->getName();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/CheckEmailRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/CheckEmailRequestBodyNormalizer.php
@@ -31,9 +31,10 @@ class CheckEmailRequestBodyNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getEmail()) {
-            $data->{'email'} = $object->getEmail();
+            $data['email'] = $object->getEmail();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/CompleteFacebookOrderRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/CompleteFacebookOrderRequestBodyNormalizer.php
@@ -50,12 +50,13 @@ class CompleteFacebookOrderRequestBodyNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getEmail()) {
-            $data->{'email'} = $object->getEmail();
+            $data['email'] = $object->getEmail();
         }
         if (null !== $object->getFbUserId()) {
-            $data->{'fbUserId'} = $object->getFbUserId();
+            $data['fbUserId'] = $object->getFbUserId();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/ConfirmRebateRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/ConfirmRebateRequestBodyNormalizer.php
@@ -40,18 +40,19 @@ class ConfirmRebateRequestBodyNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getEmail()) {
-            $data->{'email'} = $object->getEmail();
+            $data['email'] = $object->getEmail();
         }
         if (null !== $object->getCode()) {
-            $data->{'code'} = $object->getCode();
+            $data['code'] = $object->getCode();
         }
         if (null !== $object->getStatus()) {
-            $data->{'status'} = $object->getStatus();
+            $data['status'] = $object->getStatus();
         }
         if (null !== $object->getPromoteOrderId()) {
-            $data->{'promoteOrderId'} = $object->getPromoteOrderId();
+            $data['promoteOrderId'] = $object->getPromoteOrderId();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/CreateFacebookOrderRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/CreateFacebookOrderRequestBodyNormalizer.php
@@ -34,12 +34,13 @@ class CreateFacebookOrderRequestBodyNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getAdId()) {
-            $data->{'adId'} = $object->getAdId();
+            $data['adId'] = $object->getAdId();
         }
         if (null !== $object->getUserId()) {
-            $data->{'userId'} = $object->getUserId();
+            $data['userId'] = $object->getUserId();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/CreateOrderRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/CreateOrderRequestBodyNormalizer.php
@@ -37,15 +37,16 @@ class CreateOrderRequestBodyNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getEmail()) {
-            $data->{'email'} = $object->getEmail();
+            $data['email'] = $object->getEmail();
         }
         if (null !== $object->getName()) {
-            $data->{'name'} = $object->getName();
+            $data['name'] = $object->getName();
         }
         if ($object->wasCompleteBySet()) {
-            $data->{'completeBy'} = $object->getCompleteBy();
+            $data['completeBy'] = $object->getCompleteBy();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/CreateSurveyReviewRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/CreateSurveyReviewRequestBodyNormalizer.php
@@ -40,18 +40,19 @@ class CreateSurveyReviewRequestBodyNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getReviewClaimedLeft()) {
-            $data->{'reviewClaimedLeft'} = $object->getReviewClaimedLeft();
+            $data['reviewClaimedLeft'] = $object->getReviewClaimedLeft();
         }
         if (null !== $object->getReviewerName()) {
-            $data->{'reviewerName'} = $object->getReviewerName();
+            $data['reviewerName'] = $object->getReviewerName();
         }
         if (null !== $object->getTitle()) {
-            $data->{'title'} = $object->getTitle();
+            $data['title'] = $object->getTitle();
         }
         if (null !== $object->getReason()) {
-            $data->{'reason'} = $object->getReason();
+            $data['reason'] = $object->getReason();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/DealImpressionsRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/DealImpressionsRequestBodyNormalizer.php
@@ -36,13 +36,14 @@ class DealImpressionsRequestBodyNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getImpressions()) {
             $values = [];
             foreach ($object->getImpressions() as $value) {
                 $values[] = $this->serializer->serialize($value, 'raw', $context);
             }
-            $data->{'impressions'} = $values;
+            $data['impressions'] = $values;
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/DealNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/DealNormalizer.php
@@ -200,173 +200,174 @@ class DealNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getCampaignId()) {
-            $data->{'campaignId'} = $object->getCampaignId();
+            $data['campaignId'] = $object->getCampaignId();
         }
         if (null !== $object->getCompanyId()) {
-            $data->{'companyId'} = $object->getCompanyId();
+            $data['companyId'] = $object->getCompanyId();
         }
         if (null !== $object->getProductId()) {
-            $data->{'productId'} = $object->getProductId();
+            $data['productId'] = $object->getProductId();
         }
         if (null !== $object->getProductName()) {
-            $data->{'productName'} = $object->getProductName();
+            $data['productName'] = $object->getProductName();
         }
         if (null !== $object->getProductDescription()) {
-            $data->{'productDescription'} = $object->getProductDescription();
+            $data['productDescription'] = $object->getProductDescription();
         }
         if (null !== $object->getCategories()) {
             $values = [];
             foreach ($object->getCategories() as $value) {
                 $values[] = $this->serializer->serialize($value, 'raw', $context);
             }
-            $data->{'categories'} = $values;
+            $data['categories'] = $values;
         }
         if (null !== $object->getMedia()) {
             $values_1 = [];
             foreach ($object->getMedia() as $value_1) {
                 $values_1[] = $this->serializer->serialize($value_1, 'raw', $context);
             }
-            $data->{'media'} = $values_1;
+            $data['media'] = $values_1;
         }
         if (null !== $object->getBoost()) {
             $values_2 = [];
             foreach ($object->getBoost() as $value_2) {
                 $values_2[] = $value_2;
             }
-            $data->{'boost'} = $values_2;
+            $data['boost'] = $values_2;
         }
         if (null !== $object->getBoostWeights()) {
             $values_3 = [];
             foreach ($object->getBoostWeights() as $value_3) {
                 $values_3[] = $value_3;
             }
-            $data->{'boostWeights'} = $values_3;
+            $data['boostWeights'] = $values_3;
         }
         if (null !== $object->getActionType()) {
-            $data->{'actionType'} = $object->getActionType();
+            $data['actionType'] = $object->getActionType();
         }
         if (null !== $object->getActionMetadata()) {
-            $data->{'actionMetadata'} = $object->getActionMetadata();
+            $data['actionMetadata'] = $object->getActionMetadata();
         }
         if (null !== $object->getActionIsPro()) {
-            $data->{'actionIsPro'} = $object->getActionIsPro();
+            $data['actionIsPro'] = $object->getActionIsPro();
         }
         if (null !== $object->getCode()) {
-            $data->{'code'} = $object->getCode();
+            $data['code'] = $object->getCode();
         }
         if (null !== $object->getConfidence()) {
-            $data->{'confidence'} = $object->getConfidence();
+            $data['confidence'] = $object->getConfidence();
         }
         if (null !== $object->getCurrency()) {
-            $data->{'currency'} = $object->getCurrency();
+            $data['currency'] = $object->getCurrency();
         }
         if (null !== $object->getDiscountPrice()) {
-            $data->{'discountPrice'} = $object->getDiscountPrice();
+            $data['discountPrice'] = $object->getDiscountPrice();
         }
         if (null !== $object->getRebateAmount()) {
-            $data->{'rebateAmount'} = $object->getRebateAmount();
+            $data['rebateAmount'] = $object->getRebateAmount();
         }
         if (null !== $object->getIsExclusive()) {
-            $data->{'isExclusive'} = $object->getIsExclusive();
+            $data['isExclusive'] = $object->getIsExclusive();
         }
         if (null !== $object->getIsNSFW()) {
-            $data->{'isNSFW'} = $object->getIsNSFW();
+            $data['isNSFW'] = $object->getIsNSFW();
         }
         if (null !== $object->getFeatured()) {
             $values_4 = [];
             foreach ($object->getFeatured() as $value_4) {
                 $values_4[] = $value_4;
             }
-            $data->{'featured'} = $values_4;
+            $data['featured'] = $values_4;
         }
         if (null !== $object->getIsUnlimited()) {
-            $data->{'isUnlimited'} = $object->getIsUnlimited();
+            $data['isUnlimited'] = $object->getIsUnlimited();
         }
         if (null !== $object->getListingMetadata()) {
-            $data->{'listingMetadata'} = $object->getListingMetadata();
+            $data['listingMetadata'] = $object->getListingMetadata();
         }
         if (null !== $object->getListingPrice()) {
-            $data->{'listingPrice'} = $object->getListingPrice();
+            $data['listingPrice'] = $object->getListingPrice();
         }
         if (null !== $object->getListingUrl()) {
-            $data->{'listingUrl'} = $object->getListingUrl();
+            $data['listingUrl'] = $object->getListingUrl();
         }
         if (null !== $object->getReviewUrl()) {
-            $data->{'reviewUrl'} = $object->getReviewUrl();
+            $data['reviewUrl'] = $object->getReviewUrl();
         }
         if (null !== $object->getMarketplace()) {
-            $data->{'marketplace'} = $object->getMarketplace();
+            $data['marketplace'] = $object->getMarketplace();
         }
         if (null !== $object->getMarketplaceId()) {
-            $data->{'marketplaceId'} = $object->getMarketplaceId();
+            $data['marketplaceId'] = $object->getMarketplaceId();
         }
         if (null !== $object->getPayloadType()) {
-            $data->{'payloadType'} = $object->getPayloadType();
+            $data['payloadType'] = $object->getPayloadType();
         }
         if (null !== $object->getRequireEmail()) {
-            $data->{'requireEmail'} = $object->getRequireEmail();
+            $data['requireEmail'] = $object->getRequireEmail();
         }
         if (null !== $object->getShippingDaysMax()) {
-            $data->{'shippingDaysMax'} = $object->getShippingDaysMax();
+            $data['shippingDaysMax'] = $object->getShippingDaysMax();
         }
         if (null !== $object->getShippingDaysMin()) {
-            $data->{'shippingDaysMin'} = $object->getShippingDaysMin();
+            $data['shippingDaysMin'] = $object->getShippingDaysMin();
         }
         if (null !== $object->getShippingPrice()) {
-            $data->{'shippingPrice'} = $object->getShippingPrice();
+            $data['shippingPrice'] = $object->getShippingPrice();
         }
         if (null !== $object->getShippingType()) {
-            $data->{'shippingType'} = $object->getShippingType();
+            $data['shippingType'] = $object->getShippingType();
         }
         if (null !== $object->getStartsAt()) {
-            $data->{'startsAt'} = $object->getStartsAt();
+            $data['startsAt'] = $object->getStartsAt();
         }
         if (null !== $object->getReturnAt()) {
-            $data->{'returnAt'} = $object->getReturnAt();
+            $data['returnAt'] = $object->getReturnAt();
         }
         if (null !== $object->getUpdatedAt()) {
-            $data->{'updatedAt'} = $object->getUpdatedAt();
+            $data['updatedAt'] = $object->getUpdatedAt();
         }
         if (null !== $object->getEndsAt()) {
-            $data->{'endsAt'} = $object->getEndsAt();
+            $data['endsAt'] = $object->getEndsAt();
         }
         if (null !== $object->getAvailable()) {
-            $data->{'available'} = $object->getAvailable();
+            $data['available'] = $object->getAvailable();
         }
         if (null !== $object->getMetadata()) {
-            $data->{'metadata'} = $object->getMetadata();
+            $data['metadata'] = $object->getMetadata();
         }
         if (null !== $object->getRemainingQuantity()) {
-            $data->{'remainingQuantity'} = $object->getRemainingQuantity();
+            $data['remainingQuantity'] = $object->getRemainingQuantity();
         }
         if (null !== $object->getDailyLimitReached()) {
-            $data->{'dailyLimitReached'} = $object->getDailyLimitReached();
+            $data['dailyLimitReached'] = $object->getDailyLimitReached();
         }
         if (null !== $object->getImmediateFollowup()) {
-            $data->{'immediateFollowup'} = $object->getImmediateFollowup();
+            $data['immediateFollowup'] = $object->getImmediateFollowup();
         }
         if (null !== $object->getScheduledFollowup()) {
-            $data->{'scheduledFollowup'} = $object->getScheduledFollowup();
+            $data['scheduledFollowup'] = $object->getScheduledFollowup();
         }
         if (null !== $object->getDailyLimit()) {
-            $data->{'dailyLimit'} = $object->getDailyLimit();
+            $data['dailyLimit'] = $object->getDailyLimit();
         }
         if (null !== $object->getVisibility()) {
-            $data->{'visibility'} = $object->getVisibility();
+            $data['visibility'] = $object->getVisibility();
         }
         if (null !== $object->getMinAge()) {
-            $data->{'minAge'} = $object->getMinAge();
+            $data['minAge'] = $object->getMinAge();
         }
         if (null !== $object->getMaxAge()) {
-            $data->{'maxAge'} = $object->getMaxAge();
+            $data['maxAge'] = $object->getMaxAge();
         }
         if (null !== $object->getGender()) {
-            $data->{'gender'} = $object->getGender();
+            $data['gender'] = $object->getGender();
         }
         if (null !== $object->getZip()) {
-            $data->{'zip'} = $object->getZip();
+            $data['zip'] = $object->getZip();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/ErrorNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/ErrorNormalizer.php
@@ -37,15 +37,16 @@ class ErrorNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getMessage()) {
-            $data->{'message'} = $object->getMessage();
+            $data['message'] = $object->getMessage();
         }
         if (null !== $object->getStatus()) {
-            $data->{'status'} = $object->getStatus();
+            $data['status'] = $object->getStatus();
         }
         if (null !== $object->getExtra()) {
-            $data->{'extra'} = $object->getExtra();
+            $data['extra'] = $object->getExtra();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/FlagDealRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/FlagDealRequestBodyNormalizer.php
@@ -37,15 +37,16 @@ class FlagDealRequestBodyNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getType()) {
-            $data->{'type'} = $object->getType();
+            $data['type'] = $object->getType();
         }
         if (null !== $object->getReportedBy()) {
-            $data->{'reportedBy'} = $object->getReportedBy();
+            $data['reportedBy'] = $object->getReportedBy();
         }
         if (null !== $object->getComment()) {
-            $data->{'comment'} = $object->getComment();
+            $data['comment'] = $object->getComment();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/FollowupNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/FollowupNormalizer.php
@@ -37,15 +37,16 @@ class FollowupNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getDays()) {
-            $data->{'days'} = $object->getDays();
+            $data['days'] = $object->getDays();
         }
         if (null !== $object->getSubject()) {
-            $data->{'subject'} = $object->getSubject();
+            $data['subject'] = $object->getSubject();
         }
         if (null !== $object->getBody()) {
-            $data->{'body'} = $object->getBody();
+            $data['body'] = $object->getBody();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/GetRebateEmailNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/GetRebateEmailNormalizer.php
@@ -31,9 +31,10 @@ class GetRebateEmailNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getFbUserId()) {
-            $data->{'fbUserId'} = $object->getFbUserId();
+            $data['fbUserId'] = $object->getFbUserId();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/GetRebateOrPromoNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/GetRebateOrPromoNormalizer.php
@@ -34,12 +34,13 @@ class GetRebateOrPromoNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getFbUserId()) {
-            $data->{'fbUserId'} = $object->getFbUserId();
+            $data['fbUserId'] = $object->getFbUserId();
         }
         if (null !== $object->getAdId()) {
-            $data->{'adId'} = $object->getAdId();
+            $data['adId'] = $object->getAdId();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/ImpressionNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/ImpressionNormalizer.php
@@ -37,15 +37,16 @@ class ImpressionNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getViews()) {
-            $data->{'views'} = $object->getViews();
+            $data['views'] = $object->getViews();
         }
         if (null !== $object->getHour()) {
-            $data->{'hour'} = $object->getHour();
+            $data['hour'] = $object->getHour();
         }
         if (null !== $object->getDate()) {
-            $data->{'date'} = $object->getDate();
+            $data['date'] = $object->getDate();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/InitializeMigrationBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/InitializeMigrationBodyNormalizer.php
@@ -31,9 +31,10 @@ class InitializeMigrationBodyNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getUserId()) {
-            $data->{'userId'} = $object->getUserId();
+            $data['userId'] = $object->getUserId();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/MediumNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/MediumNormalizer.php
@@ -43,21 +43,22 @@ class MediumNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getId()) {
-            $data->{'id'} = $object->getId();
+            $data['id'] = $object->getId();
         }
         if (null !== $object->getUrl()) {
-            $data->{'url'} = $object->getUrl();
+            $data['url'] = $object->getUrl();
         }
         if (null !== $object->getType()) {
-            $data->{'type'} = $object->getType();
+            $data['type'] = $object->getType();
         }
         if (null !== $object->getTitle()) {
-            $data->{'title'} = $object->getTitle();
+            $data['title'] = $object->getTitle();
         }
         if (null !== $object->getMetadata()) {
-            $data->{'metadata'} = $object->getMetadata();
+            $data['metadata'] = $object->getMetadata();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/NotifyDealRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/NotifyDealRequestBodyNormalizer.php
@@ -37,15 +37,16 @@ class NotifyDealRequestBodyNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getType()) {
-            $data->{'type'} = $object->getType();
+            $data['type'] = $object->getType();
         }
         if (null !== $object->getTitle()) {
-            $data->{'title'} = $object->getTitle();
+            $data['title'] = $object->getTitle();
         }
         if (null !== $object->getBody()) {
-            $data->{'body'} = $object->getBody();
+            $data['body'] = $object->getBody();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/PayloadNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/PayloadNormalizer.php
@@ -43,21 +43,22 @@ class PayloadNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getId()) {
-            $data->{'id'} = $object->getId();
+            $data['id'] = $object->getId();
         }
         if (null !== $object->getPayload()) {
-            $data->{'payload'} = $object->getPayload();
+            $data['payload'] = $object->getPayload();
         }
         if (null !== $object->getType()) {
-            $data->{'type'} = $object->getType();
+            $data['type'] = $object->getType();
         }
         if (null !== $object->getConfirmationEmail()) {
-            $data->{'confirmationEmail'} = $object->getConfirmationEmail();
+            $data['confirmationEmail'] = $object->getConfirmationEmail();
         }
         if (null !== $object->getCompleteBy()) {
-            $data->{'completeBy'} = $object->getCompleteBy();
+            $data['completeBy'] = $object->getCompleteBy();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/PayoutRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/PayoutRequestBodyNormalizer.php
@@ -31,9 +31,10 @@ class PayoutRequestBodyNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getEmail()) {
-            $data->{'email'} = $object->getEmail();
+            $data['email'] = $object->getEmail();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/RestoreRebateRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/RestoreRebateRequestBodyNormalizer.php
@@ -34,12 +34,13 @@ class RestoreRebateRequestBodyNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getEmail()) {
-            $data->{'email'} = $object->getEmail();
+            $data['email'] = $object->getEmail();
         }
         if (null !== $object->getPromoteOrderId()) {
-            $data->{'promoteOrderId'} = $object->getPromoteOrderId();
+            $data['promoteOrderId'] = $object->getPromoteOrderId();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/ReviewFoundRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/ReviewFoundRequestBodyNormalizer.php
@@ -52,30 +52,31 @@ class ReviewFoundRequestBodyNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getCreatedAt()) {
-            $data->{'createdAt'} = $object->getCreatedAt();
+            $data['createdAt'] = $object->getCreatedAt();
         }
         if (null !== $object->getAsin()) {
-            $data->{'asin'} = $object->getAsin();
+            $data['asin'] = $object->getAsin();
         }
         if (null !== $object->getTitle()) {
-            $data->{'title'} = $object->getTitle();
+            $data['title'] = $object->getTitle();
         }
         if (null !== $object->getSummary()) {
-            $data->{'summary'} = $object->getSummary();
+            $data['summary'] = $object->getSummary();
         }
         if (null !== $object->getReviewerId()) {
-            $data->{'reviewerId'} = $object->getReviewerId();
+            $data['reviewerId'] = $object->getReviewerId();
         }
         if (null !== $object->getReviewId()) {
-            $data->{'reviewId'} = $object->getReviewId();
+            $data['reviewId'] = $object->getReviewId();
         }
         if (null !== $object->getUrl()) {
-            $data->{'url'} = $object->getUrl();
+            $data['url'] = $object->getUrl();
         }
         if (null !== $object->getStars()) {
-            $data->{'stars'} = $object->getStars();
+            $data['stars'] = $object->getStars();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/StoreConversionIdRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/StoreConversionIdRequestBodyNormalizer.php
@@ -34,12 +34,13 @@ class StoreConversionIdRequestBodyNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getConversionId()) {
-            $data->{'conversionId'} = $object->getConversionId();
+            $data['conversionId'] = $object->getConversionId();
         }
         if (null !== $object->getEmail()) {
-            $data->{'email'} = $object->getEmail();
+            $data['email'] = $object->getEmail();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/StoreFBImpressionRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/StoreFBImpressionRequestBodyNormalizer.php
@@ -31,9 +31,10 @@ class StoreFBImpressionRequestBodyNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getFbAdId()) {
-            $data->{'fbAdId'} = $object->getFbAdId();
+            $data['fbAdId'] = $object->getFbAdId();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/SyncDealRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/SyncDealRequestBodyNormalizer.php
@@ -37,15 +37,16 @@ class SyncDealRequestBodyNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getUrl()) {
-            $data->{'url'} = $object->getUrl();
+            $data['url'] = $object->getUrl();
         }
         if (null !== $object->getNote()) {
-            $data->{'note'} = $object->getNote();
+            $data['note'] = $object->getNote();
         }
         if (null !== $object->getState()) {
-            $data->{'state'} = $object->getState();
+            $data['state'] = $object->getState();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/SyncEmailForOrdersRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/SyncEmailForOrdersRequestBodyNormalizer.php
@@ -34,12 +34,13 @@ class SyncEmailForOrdersRequestBodyNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getNewEmail()) {
-            $data->{'newEmail'} = $object->getNewEmail();
+            $data['newEmail'] = $object->getNewEmail();
         }
         if (null !== $object->getOldEmail()) {
-            $data->{'oldEmail'} = $object->getOldEmail();
+            $data['oldEmail'] = $object->getOldEmail();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/UnsyncDealRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/UnsyncDealRequestBodyNormalizer.php
@@ -34,12 +34,13 @@ class UnsyncDealRequestBodyNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getNote()) {
-            $data->{'note'} = $object->getNote();
+            $data['note'] = $object->getNote();
         }
         if (null !== $object->getState()) {
-            $data->{'state'} = $object->getState();
+            $data['state'] = $object->getState();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/UpdateDeliverableRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/UpdateDeliverableRequestBodyNormalizer.php
@@ -37,15 +37,16 @@ class UpdateDeliverableRequestBodyNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getEmail()) {
-            $data->{'email'} = $object->getEmail();
+            $data['email'] = $object->getEmail();
         }
         if (null !== $object->getDeliverable()) {
-            $data->{'deliverable'} = $object->getDeliverable();
+            $data['deliverable'] = $object->getDeliverable();
         }
         if (null !== $object->getPromoteOrderId()) {
-            $data->{'promoteOrderId'} = $object->getPromoteOrderId();
+            $data['promoteOrderId'] = $object->getPromoteOrderId();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/UpdateOrderRequestBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/UpdateOrderRequestBodyNormalizer.php
@@ -31,9 +31,10 @@ class UpdateOrderRequestBodyNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getStatus()) {
-            $data->{'status'} = $object->getStatus();
+            $data['status'] = $object->getStatus();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/UpdateReviewNameBodyNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/UpdateReviewNameBodyNormalizer.php
@@ -34,12 +34,13 @@ class UpdateReviewNameBodyNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getUserEmail()) {
-            $data->{'userEmail'} = $object->getUserEmail();
+            $data['userEmail'] = $object->getUserEmail();
         }
         if (null !== $object->getNewReviewerName()) {
-            $data->{'newReviewerName'} = $object->getNewReviewerName();
+            $data['newReviewerName'] = $object->getNewReviewerName();
         }
 
         return $data;

--- a/php/src/Snagshout/Promote/Normalizer/VersionNormalizer.php
+++ b/php/src/Snagshout/Promote/Normalizer/VersionNormalizer.php
@@ -43,21 +43,22 @@ class VersionNormalizer extends AbstractNormalizer
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $data = new \stdClass();
+        $data = [];
+
         if (null !== $object->getApi()) {
-            $data->{'api'} = $object->getApi();
+            $data['api'] = $object->getApi();
         }
         if (null !== $object->getApp()) {
-            $data->{'app'} = $object->getApp();
+            $data['app'] = $object->getApp();
         }
         if (null !== $object->getDate()) {
-            $data->{'date'} = $object->getDate();
+            $data['date'] = $object->getDate();
         }
         if (null !== $object->getPhp()) {
-            $data->{'php'} = $object->getPhp();
+            $data['php'] = $object->getPhp();
         }
         if (null !== $object->getExtensions()) {
-            $data->{'extensions'} = $object->getExtensions();
+            $data['extensions'] = $object->getExtensions();
         }
 
         return $data;


### PR DESCRIPTION
**Summary**
Updated all normalizers to return an `array` instead of `stdClass` in `normalize()`.